### PR TITLE
Update imds adapter to advertising to reflect the ownership change

### DIFF
--- a/dev-docs/bidders/advertising.md
+++ b/dev-docs/bidders/advertising.md
@@ -1,10 +1,10 @@
 ---
 layout: bidder
-title: iMedia Digital Services (iMDS)
-description: Prebid iMedia Digital Services Bidder (iMDS) Adapter (replaced by "Advertising.com")
+title: Advertising.com
+description: Prebid Advertising.com Bidder Adapter
 pbjs: true
 pbs: true
-biddercode: imds
+biddercode: advertising
 tcfeu_supported: false
 usp_supported: true
 userIds: all
@@ -27,11 +27,11 @@ sidebarType: 1
 
 ### Note
 
-The iMedia Digital Services (iMDS) bidder adapter has been renamed to the [Advertising.com](/dev-docs/bidders/advertising.html) adapter, using a bidder code of `advertising`. Please update your implementation accordingly. This bidder adapter requires setup and approval from Advertising.com. Please reach out to your account manager for more information and to start using it.
+The Advertising.com bidder adapter requires setup and approval from Advertising.com. Please reach out to your account manager for more information and to start using it.
 
 ### Configuration
 
-iMedia Digital Services requires that `iframe` is used for user syncing.
+Advertising.com requires that `iframe` is used for user syncing.
 
 Example configuration:
 
@@ -74,8 +74,8 @@ https://track.technoratimedia.com/openrtb/tags?ID=%%PATTERN:hb_uuid_synacormedia
 {: .table .table-bordered .table-striped }
 | Name | Scope | Description | Example | Type |
 | ---- | ----- | ----------- | ------- | ---- |
-| `seatId` | required | The seat ID from iMedia Digital Services. This will be the same for all ad units. | `'prebid'` | `string` |
-| `tagId` | required | The placement ID or tag ID from iMedia Digital Services. | `'demo1'` | `string` |
+| `seatId` | required | The seat ID from Advertising.com. This will be the same for all ad units. | `'prebid'` | `string` |
+| `tagId` | required | The placement ID or tag ID from Advertising.com. | `'demo1'` | `string` |
 | `placementId` | optional | Legacy parameter replaced by `tagId` | `'demo1'` | `string` |
 | `bidfloor` | optional | Legacy parameter for floor price for the request. Replaced by [Price Floors Module](/dev-docs/modules/floors.html) | `0.1` | `float` |
 
@@ -100,7 +100,7 @@ var adUnits = [{
         }
     },
     "bids": [{
-        "bidder": "imds",
+        "bidder": "advertising",
         "params": {
             "seatId": "prebid",
             "tagId": "demo1",

--- a/dev-docs/bidders/synacormedia.md
+++ b/dev-docs/bidders/synacormedia.md
@@ -1,7 +1,7 @@
 ---
 layout: bidder
 title: Synacor Media
-description: Prebid Synacor Media Bidder Adapter (replaced by "imds")
+description: Prebid Synacor Media Bidder Adapter (replaced by "Advertising.com")
 pbjs: true
 pbs: true
 biddercode: synacormedia
@@ -22,9 +22,9 @@ multiformat_supported: will-bid-on-any
 prebid_member: false
 gvl_id: none
 sidebarType: 1
-pbjs_version_notes: use imds after 8.0
+pbjs_version_notes: use imds after 8.0 and advertising after 9.0
 ---
 
 ### Note
 
-The Synacor Media bidder adapter has been renamed to the [iMedia Digital Services (iMDS)](/dev-docs/bidders/imds.html) adapter, using an bidder code of `imds`. Please update your implementation accordingly.
+The Synacor Media bidder adapter has been renamed to the [Advertising.com](/dev-docs/bidders/advertising.html) adapter, using an bidder code of `advertising`. Please update your implementation accordingly.


### PR DESCRIPTION
<!--
Thanks for improving the documentation 😃
Please give a short description and check the matching checkboxes to help us review this as quick as possible.

Please make the PR writeable. This allows us to fix typos, grammar and linting errors ourselves, which makes
merging and reviewing a lot faster for everybody.

⚠️ The documentation is merged after the related code changes are merged and release ⚠️
-->
To reflect the ownership change from IMDS to Advertising.com, this change renames the `imds` adapter to `advertising` while allowing existing implementations to continue using `imds` and `synacormedia`. This also updates the features in the documentation to reflect what's already supported in the current master branch.

## 🏷 Type of documentation
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] new bid adapter
- [X] update bid adapter
- [ ] new feature
- [X] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

## 📋 Checklist
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [X] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
